### PR TITLE
Add basic CI/CD to build and publish to NuGet

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -16,19 +16,15 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Set dist name
-        run: |
-          echo "distdir=${{ github.workspace  }}/bin" >> "$GITHUB_ENV"
-
       - name: Build project
         run: |
-          dotnet publish -c Release -o ${{ env.distdir }} --runtime win-x64 ${{ github.workspace  }}/Spz.NET/
-          dotnet publish -c Release -o ${{ env.distdir }} --runtime linux-x64 ${{ github.workspace  }}/Spz.NET/
-          dotnet publish -c Release -o ${{ env.distdir }} --runtime win-arm64 ${{ github.workspace  }}/Spz.NET/
-          dotnet publish -c Release -o ${{ env.distdir }} --runtime linux-arm64 ${{ github.workspace  }}/Spz.NET/
+          dotnet publish -c Release --runtime win-x64 ${{ github.workspace  }}/Spz.NET/
+          dotnet publish -c Release --runtime linux-x64 ${{ github.workspace  }}/Spz.NET/
+          dotnet publish -c Release --runtime win-arm64 ${{ github.workspace  }}/Spz.NET/
+          dotnet publish -c Release --runtime linux-arm64 ${{ github.workspace  }}/Spz.NET/
       
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
           name: spz-net
-          path: ${{ env.distdir }}
+          path: ${{ github.workspace  }}/Spz.NET/bin/Release

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -11,29 +11,24 @@ on:
 
 jobs:
   build:
-    strategy:
-      matrix:
-        osver: [ubuntu-latest, ubuntu-24.04-arm]
-    runs-on: ${{ matrix.osver }}
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
       - name: Set dist name
         run: |
-          if ${{ matrix.osver == 'ubuntu-24.04-arm' }}; then
-            echo "distname=spz-net-arm" >> "$GITHUB_ENV"
-          else
-            echo "distname=spz-net" >> "$GITHUB_ENV"
-          fi
           echo "distdir=${{ github.workspace  }}/bin" >> "$GITHUB_ENV"
 
       - name: Build project
         run: |
-          dotnet publish -c Release -o ${{ env.distdir }} ${{ github.workspace  }}/Spz.NET/
+          dotnet publish -c Release -o ${{ env.distdir }} --runtime win-x64 ${{ github.workspace  }}/Spz.NET/
+          dotnet publish -c Release -o ${{ env.distdir }} --runtime linux-x64 ${{ github.workspace  }}/Spz.NET/
+          dotnet publish -c Release -o ${{ env.distdir }} --runtime win-arm64 ${{ github.workspace  }}/Spz.NET/
+          dotnet publish -c Release -o ${{ env.distdir }} --runtime linux-arm64 ${{ github.workspace  }}/Spz.NET/
       
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ env.distname }}
+          name: spz-net
           path: ${{ env.distdir }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,39 @@
+name: "Build"
+
+on:
+  push:
+    paths_ignore:
+      - '**/*.md'
+  pull_request:
+    paths_ignore:
+      - '**/*.md'
+
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        osver: [ubuntu-latest, ubuntu-24.04-arm]
+    runs-on: ${{ matrix.osver }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set dist name
+        run: |
+          if ${{ matrix.osver == 'ubuntu-24.04-arm' }}; then
+            echo "distname=spz-net-arm" >> "$GITHUB_ENV"
+          else
+            echo "distname=spz-net" >> "$GITHUB_ENV"
+          fi
+          echo "distdir=${{ github.workspace  }}/bin" >> "$GITHUB_ENV"
+
+      - name: Build project
+        run: |
+          dotnet publish -c Release -o ${{ env.distdir }} ${{ github.workspace  }}/Spz.NET/
+      
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ env.distname }}
+          path: ${{ env.distdir }}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -26,4 +26,4 @@ jobs:
 
       - name: Publish to NuGet
         run: |
-          dotnet nuget push ${{ env.distdir }} *.nupkg --api-key ${{ secrets.GH_TOKEN }} --source "https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json"
+          dotnet nuget push ${{ env.distdir }}/*.nupkg --api-key ${{ secrets.GH_TOKEN }} --source "https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json"

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -26,4 +26,4 @@ jobs:
 
       - name: Publish to NuGet
         run: |
-          dotnet nuget push ${{ env.distdir }}/*.nupkg --api-key ${{ secrets.GH_TOKEN }} --source "https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json"
+          dotnet nuget push ${{ env.distdir }}/*.nupkg --api-key ${{ secrets.GITHUB_TOKEN }} --source "https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json"

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,9 +1,8 @@
 name: "Publish Spz.NET"
 
 on:
-  push:
-#  release:
-#    types: [published]
+  release:
+    types: [published]
 
 
 jobs:

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,29 @@
+name: "Publish Spz.NET"
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+
+jobs:
+  publish:
+    strategy:
+      matrix:
+        osver: [ubuntu-latest, ubuntu-24.04-arm]
+    runs-on: ${{ matrix.osver }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set distdir
+        run: |
+          echo "distdir=${{ github.workspace  }}/nuget" >> "$GITHUB_ENV"
+
+      - name: Build project
+        run: |
+          dotnet pack -c Release -o ${{ env.distdir }} ${{ github.workspace  }}/Spz.NET/
+
+      - name: Publish to NuGet
+        run: |
+          dotnet nuget push ${{ env.distdir }} *.nupkg --api-key ${{ secrets.GH_TOKEN }} --source "https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json"

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,16 +1,14 @@
 name: "Publish Spz.NET"
 
 on:
-  release:
-    types: [published]
+  push:
+#  release:
+#    types: [published]
 
 
 jobs:
   publish:
-    strategy:
-      matrix:
-        osver: [ubuntu-latest, ubuntu-24.04-arm]
-    runs-on: ${{ matrix.osver }}
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,9 +1,9 @@
 name: "Publish Spz.NET"
 
 on:
-  release:
-    types: [published]
-  workflow_dispatch:
+  push:
+#  release:
+#    types: [published]
 
 
 jobs:


### PR DESCRIPTION
This PR adds two CI/CD scripts:

`build.yaml`:
- Builds Spz.NET for `win-x64`, `linux-x64`, `win-arm64`, `linux-arm64`
- Puts them in their respective directories
- Zips everything into an artifact and uploads it

`publish.yaml`:
- On release creation, will pack Spz.NET
- Upload it to the GitHub NuGet registry

It should be trivial to modify this one to publish to the Microsoft one.

---

I'm aware some stuff is really sub-optimal in this PR, reason is that it's starting to be late here, and I'm very tired.
Feel free to just reject this PR and cherry-pick what you need if it's too bad.