### PR TITLE
Fix spz buffers not being read to their completion, causing incomplete/corrupted decoding

### DIFF
--- a/Spz.NET.Tests/DeserializationTests.cs
+++ b/Spz.NET.Tests/DeserializationTests.cs
@@ -1,0 +1,26 @@
+﻿using System.Numerics;
+using Spz.NET.Helpers;
+
+namespace Spz.NET.Tests;
+
+[TestClass]
+public sealed class DeserializationTests
+{
+    [TestMethod]
+    public void DeserializeSpzTest()
+    {
+        var cloud = Spz.NET.Serialization.SplatSerializer.FromSpz(@"hornedlizard.spz");
+
+        Assert.IsNotNull(cloud);
+        Assert.AreNotEqual(0, cloud.Count, 0);
+
+        for(int i = 0; i < cloud.Count; i++)
+        {
+            var splat = cloud[i];
+
+            Assert.AreNotEqual(Vector3.Zero, splat.Position);
+            Assert.AreNotEqual(Quaternion.Zero, splat.Rotation);
+            Assert.AreNotEqual(Vector3.Zero, splat.Scale);
+        }
+    }
+}

--- a/Spz.NET.Tests/DeserializationTests.cs
+++ b/Spz.NET.Tests/DeserializationTests.cs
@@ -18,9 +18,9 @@ public sealed class DeserializationTests
         {
             var splat = cloud[i];
 
-            Assert.AreNotEqual(Vector3.Zero, splat.Position);
-            Assert.AreNotEqual(Quaternion.Zero, splat.Rotation);
-            Assert.AreNotEqual(Vector3.Zero, splat.Scale);
+            Assert.AreNotEqual(Vector3.Zero, splat.Position, $"Zero position at index {i}");
+            Assert.AreNotEqual(Quaternion.Zero, splat.Rotation, $"Zero rotation at index {i}");
+            Assert.AreNotEqual(Vector3.Zero, splat.Scale, $"Zero scale at index {i}");
         }
     }
 }

--- a/Spz.NET.Tests/Spz.NET.Tests.csproj
+++ b/Spz.NET.Tests/Spz.NET.Tests.csproj
@@ -20,4 +20,10 @@
     <Using Include="Microsoft.VisualStudio.TestTools.UnitTesting" />
   </ItemGroup>
 
+  <ItemGroup>
+    <None Update="hornedlizard.spz">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
 </Project>

--- a/Spz.NET/Helpers/BinaryHelpers.cs
+++ b/Spz.NET/Helpers/BinaryHelpers.cs
@@ -52,14 +52,16 @@ public static class BinaryHelpers
 
 
     // These read and write helpers were basically just lifted from the .NET source and backported. All my homies love spans.
-    public static void Read(this BinaryReader reader, Span<byte> buffer)
+    public static int Read(this BinaryReader reader, Span<byte> buffer)
     {
         byte[] array = ArrayPool<byte>.Shared.Rent(buffer.Length);
 
         try
         {
-            reader.Read(array, 0, buffer.Length);
-            array.AsSpan()[..buffer.Length].CopyTo(buffer);
+            int read = reader.Read(array, 0, buffer.Length);
+            array.AsSpan()[..read].CopyTo(buffer);
+
+            return read;
         }
         finally
         {

--- a/Spz.NET/Serialization/SplatSerializer/SpzSerialization.cs
+++ b/Spz.NET/Serialization/SplatSerializer/SpzSerialization.cs
@@ -44,13 +44,27 @@ public static partial class SplatSerializer
         Span<QuantizedQuat> rotSpan = rotations.Span;
         Span<byte> harmonicSpan = harmonics.Span;
 
-        reader.Read(positions.Bytes);
-        reader.Read(alphas.Bytes);
-        reader.Read(colors.Bytes);
-        reader.Read(scales.Bytes);
-        reader.Read(rotations.Bytes);
-        reader.Read(harmonics.Bytes);
+        void ReadAll(Span<byte> buffer)
+        {
+            var toRead = buffer.Length;
 
+            while (toRead > 0)
+            {
+                int read = reader.Read(buffer.Slice(buffer.Length - toRead));
+
+                if (read == 0)
+                    throw new EndOfStreamException("Unexpected end of stream");
+
+                toRead -= read;
+            }
+        }
+
+        ReadAll(positions.Bytes);
+        ReadAll(alphas.Bytes);
+        ReadAll(colors.Bytes);
+        ReadAll(scales.Bytes);
+        ReadAll(rotations.Bytes);
+        ReadAll(harmonics.Bytes);
 
         int i = count;
         while (i-- > 0)


### PR DESCRIPTION
I ran into issue where under some environments (like under .NET 9), the library wouldn't properly decode the spz files. Large chunks of data would be missing or be corrupted.

The underlying cause is that the Read methods for buffers is not guaranteed to actually read the provided amount of bytes - due to various buffering/environment/implementation differences, it can only read smaller chunk in one go. It is expected that the number of bytes read is checked and further reads are done to ensure the entire buffer is read.

This was missing from the implementation in the library.

In this PR I've:
- Added Unit test that checks for the file being fully decoded
- Fixed the issue, so the Unit test is now passing