### PR TITLE
Fix for fractional bits not used in GaussianCloud construction

### DIFF
--- a/Spz.NET/Serialization/SplatSerializer/SpzSerialization.cs
+++ b/Spz.NET/Serialization/SplatSerializer/SpzSerialization.cs
@@ -27,7 +27,8 @@ public static partial class SplatSerializer
         int count = (int)header.NumPoints;
         int shDim = SplatMathHelpers.DimForDegree(header.ShDegree);
         int shCount = shDim * 3;
-        GaussianCloud cloud = new(count, shDim, header.Flags);
+        int fractionalBits = header.FractionalBits > 0 ? header.FractionalBits : 12;
+        GaussianCloud cloud = new(count, shDim, header.Flags, fractionalBits);
 
 
         using QuickArray<FixedVector3> positions = new(count);
@@ -73,7 +74,7 @@ public static partial class SplatSerializer
             harmonicSpan.Unquantize(out GaussianHarmonics gaussianHarmonics, offset, shCount);
 
             cloud[i] = new(
-                posSpan[i].ToVector3(12),
+                posSpan[i].ToVector3(fractionalBits),
                 scaleSpan[i],
                 rotSpan[i],
                 alphaSpan[i],
@@ -109,23 +110,23 @@ public static partial class SplatSerializer
     /// <param name="stream">The stream to serialize this compressed gaussian cloud to.</param>
     public static void ToSpz(this GaussianCloud gaussians, Stream stream)
     {
+        int count = gaussians.Count;
+        int shCount = gaussians.ShDim * 3;
+        int fractionalBits = gaussians.FractionalBits > 0 ? gaussians.FractionalBits : 12;
+
         SpzHeader header = new(
             SpzHeader.MAGIC,
             SpzHeader.VERSION,
             (uint)gaussians.Count,
             (byte)gaussians.ShDegree,
-            (byte)gaussians.FractionalBits,
+            (byte)fractionalBits,
             gaussians.Flags
         );
-
 
         using GZipStream zipper = new(stream, CompressionLevel.Optimal);
         using BinaryWriter writer = new(zipper);
 
         header.WriteTo(writer);
-
-        int count = gaussians.Count;
-        int shCount = gaussians.ShDim * 3;
 
         using QuickArray<FixedVector3> positions = new(count);
         using QuickArray<QuantizedAlpha> alphas = new(count);
@@ -148,7 +149,7 @@ public static partial class SplatSerializer
         {
             int offset = i * shCount;
             Gaussian cur = gaussians[i];
-            posSpan[i] = cur.Position.ToFixed(12);
+            posSpan[i] = cur.Position.ToFixed(fractionalBits);
             alphaSpan[i] = cur.Alpha;
             colorSpan[i] = cur.Color;
             scaleSpan[i] = cur.Scale;

--- a/Spz.NET/Storage/Gaussians/Collections/GaussianCloud.cs
+++ b/Spz.NET/Storage/Gaussians/Collections/GaussianCloud.cs
@@ -17,7 +17,7 @@ namespace Spz.NET;
 /// <param name="capacity">The capacity of the cloud.</param>
 /// <param name="shDim">The dimensions of each gaussian's spherical harmonics.</param>
 /// <param name="flags">The collection flags.</param>
-public class GaussianCloud(int capacity, int shDim, GaussianFlags flags = 0) : GaussianCollection(capacity, shDim, flags)
+public class GaussianCloud(int capacity, int shDim, GaussianFlags flags = 0, int fractionalBits = 12) : GaussianCollection(capacity, shDim, flags, fractionalBits)
 {
     /// <inheritdoc/>
     public override bool Compressed => false;


### PR DESCRIPTION
## Fix: `fractional_bits` not propagated in `FromSpz`, collapsing all splat positions to a single point

---

### Bug

`SplatSerializer.FromSpz` read the `fractional_bits` field from the SPZ header but did not forward it to the constructed `GaussianCloud`. As a result, `GaussianCloud.FractionalBits` was always left at its default value of `-1`.

This value is used during position decoding — each stored integer coordinate is divided by `2^fractionalBits` to recover the floating-point position. With `fractional_bits = 255` written in the header, the divisor becomes astronomically large, mapping every position to approximately zero.

When `ToSpz` later re-serialised the cloud, it cast that `-1` directly to `byte`, writing `255` into the header's `fractional_bits` field. Every position coordinate was then decoded using a wildly incorrect fixed-point scale, mapping all Gaussian positions to approximately zero — making the entire splat appear as a **single massive point** in the scene.

---

### Fix

- [`FromSpz`](https://github.com/Yellow-Dog-Man/Spz.NET/Serialization/SplatSerializer/SplatSerializer.Spz.cs) now reads `fractional_bits` from the header and passes it through to `GaussianCloud`.
- [`ToSpz`](https://github.com/Yellow-Dog-Man/Spz.NET/Serialization/SplatSerializer/SplatSerializer.Spz.cs) guards against an invalid stored value (`<= 0`) by falling back to the standard default of `12` fractional bits before writing the header.

---

### Impact

Without this fix, any round-trip through `FromSpz` → `ToSpz` **silently corrupted all position data**. Every splat produced after the coordinate-space conversion appeared collapsed to the origin regardless of the actual scene content.
